### PR TITLE
Created vanilla folder for USGS TerriaMap

### DIFF
--- a/vanilla/Dockerfile
+++ b/vanilla/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:boron
+
+MAINTAINER Siavash Ameli <samei@berkeley.edu>
+LABEL Description="TerriaJS dockerized."
+
+# ------------
+# Nodejs, Gdal
+# ------------
+
+RUN apt-get update && apt-get install -y git gdal-bin
+RUN apt-get update && apt-get install -y git nodejs
+
+# ---------------------
+# TerriaJS installation
+# ---------------------
+
+RUN npm install -g gulp
+RUN mkdir -p /usr/local/app/
+WORKDIR /usr/local/app/
+RUN git clone https://github.com/zdefne-usgs/TerriaMap
+WORKDIR /usr/local/app/TerriaMap
+
+# Disabling the disclaimer page at startup.
+# RUN sed -i '2s/.*/The information on this website is not for navigation purposes./' lib/Views/GlobalDisclaimer.html
+
+RUN npm install
+RUN npm run gulp
+EXPOSE 3001
+
+# --------------------
+# Run within container
+# --------------------
+
+# This section turns when the image is running as a container.
+# Only the last CMD is running, so I commented the gulp watch command.
+
+CMD [ "node", "node_modules/terriajs-server/lib/app.js", "--config-file", "devserverconfig.json" ]

--- a/vanilla/README.md
+++ b/vanilla/README.md
@@ -1,7 +1,7 @@
 Dockerfile for installing the USGS TerriaMap (builds the image from the repo `zdefne-usgs/TerriaMap` )
  - Dockerfile
 
-Files to map in the docker-compose file:
+Files to map in the docker-compose fil (edit the tokkens in `deveserver_config.json` ):
  - deveserver_config.json 
  - config.json
  - usgs.json

--- a/vanilla/README.md
+++ b/vanilla/README.md
@@ -1,4 +1,4 @@
-Dockerfile for for installing the USGS TerriaMap
+Dockerfile for installing the USGS TerriaMap (builds the image from the repo zdefne-usgs/TerriaMap
  - Dockerfile
 
 Files to map in the docker-compose file:

--- a/vanilla/README.md
+++ b/vanilla/README.md
@@ -1,0 +1,13 @@
+Dockerfile for for installing the USGS TerriaMap
+ - Dockerfile
+
+Files to map in the docker-compose file:
+ - deveserver_config.json 
+ - config.json
+ - usgs.json
+ 
+ Example for a script to run to restart build the image an restart the docker container:
+  - apply_Changes.sh
+
+
+ 

--- a/vanilla/README.md
+++ b/vanilla/README.md
@@ -1,4 +1,4 @@
-Dockerfile for installing the USGS TerriaMap (builds the image from the repo `zdefne-usgs/TerriaMap`)
+Dockerfile for installing the USGS TerriaMap (builds the image from the repo `zdefne-usgs/TerriaMap` )
  - Dockerfile
 
 Files to map in the docker-compose file:

--- a/vanilla/README.md
+++ b/vanilla/README.md
@@ -1,4 +1,4 @@
-Dockerfile for installing the USGS TerriaMap (builds the image from the repo zdefne-usgs/TerriaMap
+Dockerfile for installing the USGS TerriaMap (builds the image from the repo `zdefne-usgs/TerriaMap`)
  - Dockerfile
 
 Files to map in the docker-compose file:

--- a/vanilla/README.md
+++ b/vanilla/README.md
@@ -1,8 +1,8 @@
 Dockerfile for installing the USGS TerriaMap (builds the image from the repo `zdefne-usgs/TerriaMap` )
  - Dockerfile
 
-Files to map in the docker-compose fil (edit the tokkens in `deveserver_config.json` ):
- - deveserver_config.json 
+Files to map in the docker-compose file (edit the tokkens in `deveserverconfig.json` ):
+ - deveserverconfig.json 
  - config.json
  - usgs.json
  

--- a/vanilla/applyChanges.sh
+++ b/vanilla/applyChanges.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd /opt/docker
+docker-compose down
+docker rmi -f terria-local
+docker rm $(docker ps -qa –no-trunc –filter "status=exited")
+docker rmi $(docker images –filter "dangling=true" -q –no-trunc)
+docker ps
+docker images
+cd ~/Docker
+docker build -t terria-local .
+cd /opt/docker
+docker-compose up -d

--- a/vanilla/applyChanges.sh
+++ b/vanilla/applyChanges.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 cd /opt/docker
-docker-compose down
+docker stop terriamap
 docker rmi -f terria-local
-docker rm $(docker ps -qa –no-trunc –filter "status=exited")
-docker rmi $(docker images –filter "dangling=true" -q –no-trunc)
+docker rm $(docker ps -qa â€“no-trunc â€“filter "status=exited")
+docker rmi $(docker images â€“filter "dangling=true" -q â€“no-trunc)
 docker ps
 docker images
 cd ~/Docker
 docker build -t terria-local .
 cd /opt/docker
-docker-compose up -d
+docker-compose up -d terriamap

--- a/vanilla/config.json
+++ b/vanilla/config.json
@@ -1,0 +1,40 @@
+{
+    initializationUrls: [
+        "usgs",
+    ],
+    parameters: {
+        disableSplitter: false,
+        autoPlay: false,
+        bingMapsKey: "AkaOmRFtjAb71cXgLwAGtLbj2RpkPKtVqAIroFQsocfurCBILxIeAWPkil7hhRy_",
+        googleUrlShortenerKey: null,
+        googleAnalyticsKey: null,
+        googleAnalyticsOptions: null,
+        disclaimer: {
+            text: "Disclaimer: The suggestions and illustrations included in this map are intended to support scientific research; however, they do not guarantee the safety of an individual or structure. The contributors and sponsors of this product do not assume liability for any injury, death, property damage, or other effects because of using this map. This map must not be used for navigation or precise spatial analysis. ",
+        },   
+        printDisclaimer:{
+            text: "Disclaimer: The suggestions and illustrations included in this map are intended to support scientific research; however, they do not guarantee the safety of an individual or structure. The contributors and sponsors of this product do not assume liability for any injury, death, property damage, or other effects because of using this map. This map must not be used for navigation or precise spatial analysis. ",
+        },
+        //globalDisclaimer: {
+            //confirmationRequired: false,
+            //buttonTitle: "I agree",
+            //title: "Disclaimer: ",
+            // If the current browser location is not prod, or is dev, then show a "not the real site" warning.
+            // The text of that is in lib/Views/DevelopmentDisclaimerPreamble.html
+            //prodHostRegex: ".\\.gov$",
+            //devHostRegex: "\\b(staging|preview|test|dev)\\.",
+           //enableOnLocalhost: false // If false, don't show this when running on localhost
+        //},  
+        developerAttribution: {
+            text: "U.S. Geological Survey",
+            link: "http://www.usgs.gov"
+        },
+        appName: "USGS Terria Map",
+        brandBarElements: [
+            "<table cellspacing=\"20\"><tr><td style=\"padding-right:18px\"> <a target=\"_blank\" href=\"https://www.usgs.gov/\"><img vertical-align=\"middle\"  src=\"https://github.com/zdefne-usgs/TerriaMap/blob/master/wwwroot/images/USGS_brand_logo.png?raw=true\" style=\"height:42;border:0\" title=\"U.S. Geological Survey\" /></a></td></tr></table>"
+        ],
+        supportEmail: "zdefne@usgs.gov",
+        proj4ServiceBaseUrl: "proj4def/",
+        feedbackUrl: "feedback",
+        }
+}

--- a/vanilla/devserverconfig.json
+++ b/vanilla/devserverconfig.json
@@ -1,0 +1,49 @@
+{
+    "port": 3001,
+
+    "allowProxyFor" : [
+        "gov",
+        "gov",
+        "org",
+        "edu",
+        "us",
+        "geocommunicator.gov",
+        "arcgisonline.com",
+        "api.github.com",
+        "githubusercontent.com",
+        "esri.com",
+        "axiomalaska.com",
+        "axds.co",
+        "ingv.it",
+        "nicta.com.au",
+        "gov.au",
+        "gov.uk",
+        "gov.nz",
+        "csiro.au",
+        "arcgis.com",
+        "argo.jcommops.org",
+        "www.abc.net.au",
+        "geoserver.aurin.org.au",
+        "mapsengine.google.com",
+        "s3-ap-southeast-2.amazonaws.com",
+        "adelaidecitycouncil.com",
+        "www.dptiapps.com.au",
+        "geoserver-123.aodn.org.au",
+        "geoserver.imos.org.au",
+        "nci.org.au",
+        "static.nationalmap.nicta.com.au"
+    ],
+    shareUrlPrefixes: {
+        "g": {
+            service: "gist",
+            accessToken: "[insert github gist tokken]"
+        }
+    },
+    newShareUrlPrefix: "g",
+    feedback: {
+        userAgent: "TerriaBot (TerriaJS Feedback)",
+        issuesUrl: "https://api.github.com/repos/[insert github account name]/[insert github repo name]/issues",
+        accessToken: "[insert github repo tokken]"
+    },
+}
+

--- a/vanilla/devserverconfig.json
+++ b/vanilla/devserverconfig.json
@@ -36,14 +36,14 @@
     shareUrlPrefixes: {
         "g": {
             service: "gist",
-            accessToken: "[insert github gist tokken]"
+            accessToken: "[insert github gist token]"
         }
     },
     newShareUrlPrefix: "g",
     feedback: {
         userAgent: "TerriaBot (TerriaJS Feedback)",
         issuesUrl: "https://api.github.com/repos/[insert github account name]/[insert github repo name]/issues",
-        accessToken: "[insert github repo tokken]"
+        accessToken: "[insert github repo token]"
     },
 }
 

--- a/vanilla/usgs.json
+++ b/vanilla/usgs.json
@@ -1,0 +1,17 @@
+{
+    "corsDomains": [
+        "corsproxy.com",
+        "programs.communications.gov.au",
+        "www.asris.csiro.au",
+        "mapsengine.google.com"
+    ],
+    "viewerMode": "2d",
+    "homeCamera": {
+        "west": -124,
+        "south": 24,
+        "east": -66,
+        "north": 50
+    },
+    "services": [],
+    "catalog": []
+}


### PR DESCRIPTION
Added vanilla folder for USGS TerriaMap. Reflects the following changes. Changes implemented through `init` and `config` files or mapping files :
 - Added USGS logo
 - Removed Related Maps button
 - Map starts in 2D map zoomed to USA
 - Added feedback tool and instructions in devserverconfig.json to customize it to use user's github tokens 
- About button redirects to USGS maps page.

Changes made by modifying the repository content or to the code:
 - Replaced  basemap layer thumbnails from AU to USA
- Modified feedback script to prevent from posting names, emails and IP address
